### PR TITLE
Add node build; make docker depend on node passing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,10 @@
 name: Docker Build
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main    
+  workflow_run:
+    workflows: ["Yarn Build"]
+    types:
+      - completed
 
 jobs:
   build:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,20 @@
+name: Yarn Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main    
+
+jobs:
+  yarn_build_prod:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - run: yarn
+    - run: yarn build-prod


### PR DESCRIPTION
Docker builds take a long time (10min+) due to cross compiling for arm.

Let's fail fast: Make sure `yarn build-prod` works prior to fiddling with Docker.